### PR TITLE
Fixed errors under emacs 24.2 and org-mode 8

### DIFF
--- a/ox-jekyll.el
+++ b/ox-jekyll.el
@@ -51,17 +51,17 @@
 
 ;;; Define Back-End
 
-(org-export-define-derived-backend 'jekyll 'html
-  :export-block '("HTML" "JEKYLL")
+(org-export-define-derived-backend jekyll html
+  :export-block ("HTML" "JEKYLL")
   :menu-entry
-  '(?j "Jekyll: export to HTML with YAML front matter."
+  (?j "Jekyll: export to HTML with YAML front matter."
        ((?H "As HTML buffer" org-jekyll-export-as-html)
         (?h "As HTML file" org-jekyll-export-to-html)))
   :translate-alist
   '((template . org-jekyll-template) ;; add YAML front matter.
     (inner-template . org-jekyll-inner-template)) ;; force body-only
   :options-alist
-  '((:jekyll-layout "JEKYLL_LAYOUT" nil org-jekyll-layout)
+   ((:jekyll-layout "JEKYLL_LAYOUT" nil org-jekyll-layout)
     (:jekyll-categories "JEKYLL_CATEGORIES" nil org-jekyll-categories)
     (:jekyll-published "JEKYLL_PUBLISHED" nil org-jekyll-published)))
 


### PR DESCRIPTION
When I tried to use org-octopress I got some run-time errors. This patch fixes them.

--dmg

p.s. thank for all the work.
