### PR TITLE
Alternate publishing using rake for yaml front matter

### DIFF
--- a/ox-jekyll.el
+++ b/ox-jekyll.el
@@ -33,6 +33,26 @@
   :group 'org-export
   :version "24.2")
 
+(defcustom org-jekyll-include-yaml-front-matter t
+  "If true, then include yaml-front-matter when exporting to html.
+
+If false, then you should include the yaml front matter like this at the top of the file:
+
+#+BEGIN_HTML
+---
+layout: post
+title: \"Upgrading Octopress\"
+date: 2013-09-15 22:08
+comments: true
+categories: [octopress, rubymine]
+keywords: Octopress
+description: Instructions on Upgrading Octopress
+---
+#+END_HTML"
+  :group 'org-export-jekyll
+  :type 'boolean)
+
+
 (defcustom org-jekyll-layout "post"
   "Default layout used in Jekyll article."
   :group 'org-export-jekyll
@@ -112,9 +132,12 @@ INFO is a plist used as a communication channel."
   "Return complete document string after HTML conversion.
 CONTENTS is the transcoded contents string. INFO is a plist
 holding export options."
-  (concat
-   (org-jekyll--yaml-front-matter info)
-   contents))
+  (if org-jekyll-include-yaml-front-matter
+      (concat
+       (org-jekyll--yaml-front-matter info)
+       contents)
+    contents
+    ))
 
 (defun org-jekyll-inner-template (contents info)
   "Return body of document string after HTML conversion.


### PR DESCRIPTION
With the changes here, I can publish per the instructions here:

http://www.railsonmaui.com/blog/2013/04/27/octopress-setup-with-github-and-org-mode/index.html

Basically, this change just allows turning off the inclusion of the yaml front matter, as that will be included per my rake technique.

There are some changes related to the configuration publishing. I'll be updating this article shortly.

This is how I setup the publishing. The key thing is turning off toc generation.

Note, these settings are with org-mode version
Org-mode version 8.2.3c

The rakefile part is the same as mentioned in the above article.

```
(setq org-publish-project-alist
      '(
        ("blog-org" .  (:base-directory "~/a/railsonmaui-octopress/source/org_posts/"
                                        :base-extension "org"
                                        :publishing-directory "~/a/railsonmaui-octopress/source/_posts/"
                                        :with-toc nil
                                        :with-sub-superscript nil 
                                        :recursive t
                                        :publishing-function org-jekyll-publish-to-html
                                        :headline-levels 4
                                        :body-only t))
        ("blog-extra" . (:base-directory "~/a/railsonmaui-octopress/source/org_posts/"
                                         :publishing-directory "~/a/railsonmaui-octopress/source/"
                                         :base-extension "css\\|pdf\\|png\\|jpg\\|gif\\|svg"
                                         :publishing-function org-publish-attachment
                                         :recursive t
                                         :author nil
                                         ))
        ("about" .  (:base-directory "~/a/railsonmaui-octopress/source/about/"
                                     :base-extension "org"
                                     :publishing-directory "~/a/railsonmaui-octopress/source/about/"
                                     :with-sub-superscript nil
                                     :with-toc nil
                                     :recursive t
                                     :publishing-function org-jekyll-publish-to-html
                                     :headline-levels 4
                                     :body-only t))
        ("meta" .  (:base-directory "~/a/railsonmaui-octopress/source/meta/"
                                    :base-extension "org"
                                    :publishing-directory "~/a/railsonmaui-octopress/source/meta/"
                                    :with-sub-superscript nil
                                    :with-toc nil
                                    :recursive t
                                    :publishing-function org-jekyll-publish-to-html
                                    :headline-levels 4
                                    :body-only t))
        ("tips" .  (:base-directory "~/a/railsonmaui-octopress/source/tips/"
                                    :base-extension "org"
                                    :publishing-directory "~/a/railsonmaui-octopress/source/tips/"
                                    :with-sub-superscript nil
                                    :with-toc nil
                                    :recursive t
                                    :publishing-function org-jekyll-publish-to-html
                                    :headline-levels 4
                                    :body-only t))

        ("blog" . (:components ("blog-org" "blog-extra about meta tips")))
        ))
```
